### PR TITLE
Always restart on crash

### DIFF
--- a/tmn/elements/service.py
+++ b/tmn/elements/service.py
@@ -70,6 +70,7 @@ class Service:
                     ports=self.ports,
                     log_config={'type': self.log_driver,
                                 'config': self.log_opts},
+                    restart_policy={"Name": "always", "MaximumRetryCount": 5},
                     detach=True
                 )
                 return True


### PR DESCRIPTION
I retained to add that in the first place because I wanted people to use docker-compose instead.
But it seems like people are still using tmn, so we might as well make it safe to use.