### PR TITLE
Remove max retries

### DIFF
--- a/tmn/elements/service.py
+++ b/tmn/elements/service.py
@@ -70,7 +70,7 @@ class Service:
                     ports=self.ports,
                     log_config={'type': self.log_driver,
                                 'config': self.log_opts},
-                    restart_policy={"Name": "always", "MaximumRetryCount": 5},
+                    restart_policy={"Name": "always"},
                     detach=True
                 )
                 return True


### PR DESCRIPTION
`MaximumRetryCount` should not be used with the `always` policy